### PR TITLE
Add multi-sig escrow service to satoshiskleinanzeigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ When the API calls back into WooCommerce it signs the JSON body together with a 
 - `x-weo-sign` is `HMAC_SHA256(secret, ts + body)`
 - Requests with missing, stale, or mismatched signatures are rejected with `401`
 
+Callbacks are delivered asynchronously with retry and exponential backoff. Configure `WEBHOOK_RETRIES` for the number of attempts
+and `WEBHOOK_BACKOFF` as the multiplier between retries (defaults: 3 retries, backoff 2). Successful final notifications record a
+timestamp in the `last_webhook_ts` column to prevent duplicate sends.
+
 ## CORS configuration
 
 The API enforces a strict origin whitelist. Set the `ALLOW_ORIGINS` environment

--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ When the API calls back into WooCommerce it signs the JSON body together with a 
 - `x-weo-ts` contains the timestamp (±5 minutes allowed)
 - `x-weo-sign` is `HMAC_SHA256(secret, ts + body)`
 - Requests with missing, stale, or mismatched signatures are rejected with `401`
+
+## CORS configuration
+
+The API enforces a strict origin whitelist. Set the `ALLOW_ORIGINS` environment
+variable to a comma-separated list of permitted shop domains.
+
+Example:
+
+```bash
+# production
+ALLOW_ORIGINS=https://shop.example.com
+
+# staging
+ALLOW_ORIGINS=https://shop-staging.example.com
+```
+
+After updating the value, redeploy the API so the new origins take effect.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,20 @@ ALLOW_ORIGINS=https://shop-staging.example.com
 ```
 
 After updating the value, redeploy the API so the new origins take effect.
+
+## Prometheus metrics
+
+The API exposes metrics under `/metrics` in the Prometheus exposition format. The following metrics are available:
+
+- `rpc_duration_seconds` – histogram of Bitcoin Core RPC latency, labelled by `method`
+- `webhook_total` – counter for webhook deliveries with label `status` (`success` or `error`)
+- `pending_signatures` – gauge for the number of missing PSBT signatures across orders
+
+Example scrape configuration:
+
+```yaml
+scrape_configs:
+  - job_name: escrow_api
+    static_configs:
+      - targets: ['api.example.com:8080']
+```

--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ alerts:
 ``` 
 
 These alerts signal that transactions failed to broadcast or orders have stalled and require manual intervention.
+
+## Signing deadlines
+
+Orders that reach `escrow_funded` or `signing` receive a signing deadline `SIGNING_DEADLINE_DAYS` (default 7 days).
+The Python API stores this as `deadline_ts` in the database and the WooCommerce plugin displays the remaining
+time in the order panel. When the deadline expires and only one party has signed, the API will automatically
+co‑sign with the escrow key and broadcast the payout or refund, depending on the stored destination.
+
+Configure the timeout period in two places:
+
+- Set the `SIGNING_DEADLINE_DAYS` environment variable for the API service.
+- In WordPress, adjust the **Signatur‑Timeout (Tage)** option under the plugin settings to match the server value.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project links a WooCommerce plugin with a Python FastAPI service to handle Bitcoin multisig escrow.
 
+## Vendor setup
+
+Dokan sellers can configure their escrow xpub under **Treuhand Service** in the vendor dashboard.
+
 ## API key management
 
 The API reads a comma-separated list of valid keys from the `API_KEYS` environment variable. You can revoke individual keys by listing them in `API_KEY_REVOKED`.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ The WooCommerce plugin holds a single active key in its settings and sends it wi
 1. Deploy a new key and add it to `API_KEYS` on the API server.
 2. Update the plugin setting with the new key.
 3. Once clients have switched, remove the old key from `API_KEYS` or move it to `API_KEY_REVOKED`.
+
+## Webhook security
+
+When the API calls back into WooCommerce it signs the JSON body together with a Unix timestamp. The plugin stores a shared HMAC secret and verifies each request:
+
+- `x-weo-ts` contains the timestamp (±5 minutes allowed)
+- `x-weo-sign` is `HMAC_SHA256(secret, ts + body)`
+- Requests with missing, stale, or mismatched signatures are rejected with `401`

--- a/README.md
+++ b/README.md
@@ -95,3 +95,30 @@ Configure the timeout period in two places:
 
 - Set the `SIGNING_DEADLINE_DAYS` environment variable for the API service.
 - In WordPress, adjust the **Signatur‑Timeout (Tage)** option under the plugin settings to match the server value.
+
+### Default escalation policy
+
+- If the buyer fails to sign within 7 days after the vendor marks the order as delivered, the escrow operator
+  may co‑sign with the vendor to complete the payout.
+- If the vendor does not deliver and remains inactive for 7 days, the escrow operator may co‑sign with the
+  buyer to refund the order.
+
+Admins can override deadlines or trigger payouts/refunds manually from the order panel if exceptional
+circumstances require intervention. Increase or decrease `SIGNING_DEADLINE_DAYS` on the server and in the
+plugin settings to customize the window for your shop.
+
+## FAQ
+
+### When does an escalation happen?
+The background worker checks `signing` orders against their `deadline_ts`. Once the timestamp has passed and
+only one signature is present, the API co‑signs and broadcasts the payout or refund automatically.
+
+### Can admins override the process?
+Yes. WordPress administrators can initiate payouts, refunds, or disputes directly from the order panel,
+which bypasses the automatic deadline handling.
+
+### Where can I find more documentation?
+- [API reference](docs/api.md)
+- [Operator guide](docs/operator-guide.md)
+- [WooCommerce user guide](docs/woo-user-guide.md)
+- [Sample Terms of Service clause](docs/terms-template.md)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Woo Escrow On-Chain
+
+This project links a WooCommerce plugin with a Python FastAPI service to handle Bitcoin multisig escrow.
+
+## API key management
+
+The API reads a comma-separated list of valid keys from the `API_KEYS` environment variable. You can revoke individual keys by listing them in `API_KEY_REVOKED`.
+
+The WooCommerce plugin holds a single active key in its settings and sends it with every request using the `x-api-key` header.
+
+### Key rotation
+1. Deploy a new key and add it to `API_KEYS` on the API server.
+2. Update the plugin setting with the new key.
+3. Once clients have switched, remove the old key from `API_KEYS` or move it to `API_KEY_REVOKED`.

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -48,3 +48,41 @@
   margin: 0 auto;
   display: block;
 }
+
+/* State Stepper */
+.weo-stepper {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  padding: 0;
+  margin: 15px 0;
+}
+.weo-stepper li {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+.weo-stepper li:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -50%;
+  width: 100%;
+  height: 2px;
+  background: #ddd;
+  transform: translateY(-50%);
+}
+.weo-stepper li span {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: #eee;
+}
+.weo-stepper li.done span {
+  background: #4caf50;
+  color: #fff;
+}
+.weo-stepper li.current span {
+  background: #2196f3;
+  color: #fff;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,16 @@
+# API Documentation
+
+The FastAPI service automatically exposes OpenAPI/Swagger documentation.
+
+- Swagger UI: `GET /docs`
+- OpenAPI schema: `GET /openapi.json`
+
+To run the API locally and view the docs:
+
+```bash
+uvicorn api:app --reload
+# visit http://localhost:8000/docs
+```
+
+The OpenAPI description lists all routes such as `/orders`, `/psbt/*`, `/tx/*` and
+includes request/response models for integration.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,42 @@
+# Operator Guide
+
+## Bitcoin Core setup
+
+1. Install Bitcoin Core >= 25 with wallet support.
+2. Create a wallet dedicated to escrow operations:
+   ```bash
+   bitcoin-cli createwallet escrow
+   ```
+3. Enable RPC access for the API user in `bitcoin.conf`:
+   ```ini
+   rpcuser=escrow
+   rpcpassword=change-me
+   ```
+4. Start `bitcoind` and ensure the API host can reach it via RPC.
+
+## Environment variables
+
+The API reads configuration from environment variables:
+
+- `BITCOIN_RPCUSER` / `BITCOIN_RPCPASSWORD`
+- `BITCOIN_RPCHOST` (default `127.0.0.1`)
+- `BITCOIN_RPCPORT` (default `8332`)
+- `API_KEYS` – comma-separated list of active keys
+- `API_KEY_REVOKED` – optional comma-separated list of revoked keys
+- `ALLOW_ORIGINS` – comma-separated list of permitted CORS origins
+- `WEBHOOK_RETRIES` – retry attempts for Woo callbacks (default 3)
+- `WEBHOOK_BACKOFF` – multiplier for exponential backoff (default 2)
+- `ORDERS_DB` – path to SQLite file (default `orders.sqlite`)
+- `SIGNING_DEADLINE_DAYS` – days before unsigned orders auto-escalate (default 7)
+- `STUCK_ORDER_HOURS` – hours before orders are reported as stuck
+
+Load these variables via systemd `Environment=` directives or a secret manager in production.
+
+## Starting the API
+
+```bash
+pip install -r requirements.txt
+uvicorn api:app --host 0.0.0.0 --port 8000
+```
+
+Monitor logs and Prometheus metrics under `/metrics` to ensure the service operates correctly.

--- a/docs/terms-template.md
+++ b/docs/terms-template.md
@@ -1,0 +1,9 @@
+# Sample Terms of Service clause
+
+_By using the escrow service, buyers and sellers agree to the following:_
+
+1. Funds are held in a 2-of-3 Bitcoin multisignature wallet controlled by the buyer, seller, and the escrow operator.
+2. If the buyer does not provide a signature within the agreed signing period after the seller marks the order as delivered, the escrow operator may co-sign with the seller to release funds to the seller.
+3. If the seller fails to deliver within the agreed signing period, the escrow operator may co-sign with the buyer to refund the order.
+4. The escrow operator acts solely as a technical facilitator and does not mediate disputes beyond the automated signing policy.
+5. Users are responsible for securing their private keys and ensuring accurate payment information.

--- a/docs/woo-user-guide.md
+++ b/docs/woo-user-guide.md
@@ -1,0 +1,20 @@
+# WooCommerce User Guide
+
+## Exporting an xpub
+
+1. In your Bitcoin wallet, locate the account you wish to use for escrow.
+2. Find the extended public key (xpub, zpub, etc.).
+3. Copy the key and paste it into the plugin’s xpub field. The plugin normalizes Slip132
+   prefixes automatically.
+
+## Signing a PSBT
+
+1. Download the partially signed transaction (PSBT) from the order page after clicking
+   the payout or refund button.
+2. Import the PSBT into your wallet:
+   - Electrum: `Tools -> Load transaction -> From file`
+   - Sparrow: `File -> Open Transaction`
+3. Sign the transaction and export the updated PSBT file.
+4. Upload the signed PSBT back on the order page using your role-specific upload form.
+
+Once both required signatures are present, the plugin will finalize and broadcast the transaction.

--- a/includes/class-escrow-checkout.php
+++ b/includes/class-escrow-checkout.php
@@ -18,7 +18,16 @@ class WEO_Checkout {
   }
 
   public function validate() {
-    if (empty($_POST['_weo_buyer_xpub'])) wc_add_notice('Bitte Escrow-xpub angeben.', 'error');
+    if (empty($_POST['_weo_buyer_xpub'])) {
+      wc_add_notice('Bitte Escrow-xpub angeben.', 'error');
+      return;
+    }
+    $norm = weo_normalize_xpub(wp_unslash($_POST['_weo_buyer_xpub']));
+    if (is_wp_error($norm)) {
+      wc_add_notice('Ungültiges xpub.', 'error');
+    } else {
+      $_POST['_weo_buyer_xpub'] = $norm;
+    }
   }
 
   public function save($order_id) {

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class WEO_Dokan {
+  public function __construct() {
+    add_filter('dokan_get_dashboard_nav', [$this,'nav']);
+    add_action('dokan_render_settings_content', [$this,'page']);
+  }
+
+  public function nav($urls) {
+    if (!current_user_can('vendor') && !current_user_can('seller')) return $urls;
+    $urls['weo-treuhand'] = [
+      'title' => __('Treuhand Service','weo'),
+      'icon'  => '<i class="dashicons-lock"></i>',
+      'url'   => dokan_get_navigation_url('weo-treuhand'),
+      'pos'   => 51,
+    ];
+    return $urls;
+  }
+
+  public function page($query_vars) {
+    if (!isset($query_vars['weo-treuhand'])) return;
+    if (!current_user_can('vendor') && !current_user_can('seller')) {
+      dokan_add_notice(__('Keine Berechtigung','weo'),'error');
+      return;
+    }
+    $user_id = get_current_user_id();
+    if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['weo_vendor_xpub'])) {
+      check_admin_referer('weo_dokan_xpub');
+      $xpub = weo_sanitize_xpub(wp_unslash($_POST['weo_vendor_xpub']));
+      update_user_meta($user_id,'weo_vendor_xpub',$xpub);
+      dokan_add_notice(__('Escrow xpub gespeichert','weo'),'success');
+    }
+    $xpub = get_user_meta($user_id,'weo_vendor_xpub',true);
+    $file = WEO_DIR.'templates/dokan-treuhand.php';
+    if (file_exists($file)) include $file;
+  }
+}

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -27,11 +27,14 @@ class WEO_Dokan {
     $user_id = get_current_user_id();
     if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['weo_vendor_xpub'])) {
       check_admin_referer('weo_dokan_xpub');
-      $xpub = weo_sanitize_xpub(wp_unslash($_POST['weo_vendor_xpub']));
+      $xpub   = weo_sanitize_xpub(wp_unslash($_POST['weo_vendor_xpub']));
+      $payout = isset($_POST['weo_vendor_payout_address']) ? weo_sanitize_btc_address(wp_unslash($_POST['weo_vendor_payout_address'])) : '';
       update_user_meta($user_id,'weo_vendor_xpub',$xpub);
-      dokan_add_notice(__('Escrow xpub gespeichert','weo'),'success');
+      if ($payout) update_user_meta($user_id,'weo_vendor_payout_address',$payout);
+      dokan_add_notice(__('Escrow-Daten gespeichert','weo'),'success');
     }
-    $xpub = get_user_meta($user_id,'weo_vendor_xpub',true);
+    $xpub   = get_user_meta($user_id,'weo_vendor_xpub',true);
+    $payout = get_user_meta($user_id,'weo_vendor_payout_address',true);
     $file = WEO_DIR.'templates/dokan-treuhand.php';
     if (file_exists($file)) include $file;
   }

--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -239,6 +239,22 @@ class WEO_Order {
 
   /** Fallback – trag hier eine Vendor-Payout-Adresse ein, falls nicht separat gepflegt */
   private function fallback_vendor_payout_address($order_id) {
+    $order = wc_get_order($order_id);
+    if ($order) {
+      $vendor_id = $order->get_meta('_weo_vendor_id');
+      if (!$vendor_id) {
+        foreach ($order->get_items('line_item') as $item) {
+          $pid = $item->get_product_id();
+          $vendor_id = get_post_field('post_author',$pid);
+          if ($vendor_id) break;
+        }
+        if ($vendor_id) { $order->update_meta_data('_weo_vendor_id',$vendor_id); $order->save(); }
+      }
+      if ($vendor_id) {
+        $payout = get_user_meta($vendor_id,'weo_vendor_payout_address',true);
+        if ($payout) return $payout;
+      }
+    }
     return get_option('weo_vendor_payout_fallback','bc1qexamplefallbackaddressxxxxxxxxxxxxxxxxxx');
   }
 }

--- a/includes/class-escrow-settings.php
+++ b/includes/class-escrow-settings.php
@@ -13,6 +13,7 @@ class WEO_Settings {
     add_settings_field('api_base', 'Escrow-API Base URL', [$this,'field_api'], 'weo', 'weo_main');
     add_settings_field('escrow_xpub', 'Escrow xpub (dein Key)', [$this,'field_xpub'], 'weo', 'weo_main');
     add_settings_field('min_conf', 'Min. Bestätigungen', [$this,'field_conf'], 'weo', 'weo_main');
+    add_settings_field('api_key', 'API Key', [$this,'field_api_key'], 'weo', 'weo_main');
   }
 
   public function sanitize($opts) {
@@ -20,6 +21,7 @@ class WEO_Settings {
     $clean['api_base']   = esc_url_raw($opts['api_base'] ?? '');
     $clean['escrow_xpub']= weo_sanitize_xpub($opts['escrow_xpub'] ?? '');
     $clean['min_conf']   = max(0, intval($opts['min_conf'] ?? 1));
+    $clean['api_key']    = sanitize_text_field($opts['api_key'] ?? '');
     return $clean;
   }
 
@@ -38,6 +40,11 @@ class WEO_Settings {
   public function field_conf() {
     $v = intval(weo_get_option('min_conf',2));
     echo "<input type='number' name='".WEO_OPT."[min_conf]' value='$v' min='0' max='6' />";
+  }
+
+  public function field_api_key() {
+    $v = esc_attr(weo_get_option('api_key',''));
+    echo "<input type='text' name='".WEO_OPT."[api_key]' value='$v' class='regular-text' />";
   }
 
   public function render() { ?>

--- a/includes/class-escrow-settings.php
+++ b/includes/class-escrow-settings.php
@@ -14,6 +14,7 @@ class WEO_Settings {
     add_settings_field('escrow_xpub', 'Escrow xpub (dein Key)', [$this,'field_xpub'], 'weo', 'weo_main');
     add_settings_field('min_conf', 'Min. Bestätigungen', [$this,'field_conf'], 'weo', 'weo_main');
     add_settings_field('api_key', 'API Key', [$this,'field_api_key'], 'weo', 'weo_main');
+    add_settings_field('hmac_secret', 'Webhook HMAC Secret', [$this,'field_hmac_secret'], 'weo', 'weo_main');
   }
 
   public function sanitize($opts) {
@@ -22,6 +23,7 @@ class WEO_Settings {
     $clean['escrow_xpub']= weo_sanitize_xpub($opts['escrow_xpub'] ?? '');
     $clean['min_conf']   = max(0, intval($opts['min_conf'] ?? 1));
     $clean['api_key']    = sanitize_text_field($opts['api_key'] ?? '');
+    $clean['hmac_secret']= sanitize_text_field($opts['hmac_secret'] ?? '');
     return $clean;
   }
 
@@ -45,6 +47,11 @@ class WEO_Settings {
   public function field_api_key() {
     $v = esc_attr(weo_get_option('api_key',''));
     echo "<input type='text' name='".WEO_OPT."[api_key]' value='$v' class='regular-text' />";
+  }
+
+  public function field_hmac_secret() {
+    $v = esc_attr(weo_get_option('hmac_secret',''));
+    echo "<input type='text' name='".WEO_OPT."[hmac_secret]' value='$v' class='regular-text' />";
   }
 
   public function render() { ?>

--- a/includes/class-escrow-settings.php
+++ b/includes/class-escrow-settings.php
@@ -15,6 +15,7 @@ class WEO_Settings {
     add_settings_field('min_conf', 'Min. Bestätigungen', [$this,'field_conf'], 'weo', 'weo_main');
     add_settings_field('api_key', 'API Key', [$this,'field_api_key'], 'weo', 'weo_main');
     add_settings_field('hmac_secret', 'Webhook HMAC Secret', [$this,'field_hmac_secret'], 'weo', 'weo_main');
+    add_settings_field('timeout_days', 'Signatur-Timeout (Tage)', [$this,'field_timeout'], 'weo', 'weo_main');
   }
 
   public function sanitize($opts) {
@@ -24,6 +25,7 @@ class WEO_Settings {
     $clean['min_conf']   = max(0, intval($opts['min_conf'] ?? 1));
     $clean['api_key']    = sanitize_text_field($opts['api_key'] ?? '');
     $clean['hmac_secret']= sanitize_text_field($opts['hmac_secret'] ?? '');
+    $clean['timeout_days']= max(1, intval($opts['timeout_days'] ?? 7));
     return $clean;
   }
 
@@ -51,7 +53,12 @@ class WEO_Settings {
 
   public function field_hmac_secret() {
     $v = esc_attr(weo_get_option('hmac_secret',''));
-    echo "<input type='text' name='".WEO_OPT."[hmac_secret]' value='$v' class='regular-text' />";
+    echo "<input type='text' name='".WEO_OPT."[hmac_secret]' value='$v' class='regular-text' />"; 
+  }
+
+  public function field_timeout() {
+    $v = intval(weo_get_option('timeout_days',7));
+    echo "<input type='number' name='".WEO_OPT."[timeout_days]' value='$v' min='1' />"; 
   }
 
   public function render() { ?>

--- a/includes/class-escrow-vendor.php
+++ b/includes/class-escrow-vendor.php
@@ -32,10 +32,16 @@ class WEO_Vendor {
   public function save($user_id) {
     if (!current_user_can('edit_user',$user_id)) return;
     if (isset($_POST['weo_vendor_xpub'])) {
-      update_user_meta($user_id,'weo_vendor_xpub', weo_sanitize_xpub(wp_unslash($_POST['weo_vendor_xpub'])));
+      $norm = weo_normalize_xpub(wp_unslash($_POST['weo_vendor_xpub']));
+      if (!is_wp_error($norm)) {
+        update_user_meta($user_id,'weo_vendor_xpub', $norm);
+      }
     }
     if (isset($_POST['weo_vendor_payout_address'])) {
-      update_user_meta($user_id,'weo_vendor_payout_address', weo_sanitize_btc_address(wp_unslash($_POST['weo_vendor_payout_address'])));
+      $addr = wp_unslash($_POST['weo_vendor_payout_address']);
+      if (weo_validate_btc_address($addr)) {
+        update_user_meta($user_id,'weo_vendor_payout_address', weo_sanitize_btc_address($addr));
+      }
     }
   }
 

--- a/includes/class-escrow-vendor.php
+++ b/includes/class-escrow-vendor.php
@@ -12,13 +12,20 @@ class WEO_Vendor {
 
   public function field($user) {
     if (!user_can($user,'vendor') && !user_can($user,'seller')) return;
-    $xpub = get_user_meta($user->ID,'weo_vendor_xpub',true);
+    $xpub   = get_user_meta($user->ID,'weo_vendor_xpub',true);
+    $payout = get_user_meta($user->ID,'weo_vendor_payout_address',true);
     ?>
     <h3>Escrow xpub (Verkäufer)</h3>
-    <table class="form-table"><tr>
-      <th><label for="weo_vendor_xpub">Vendor xpub</label></th>
-      <td><input type="text" class="regular-text code" name="weo_vendor_xpub" id="weo_vendor_xpub" value="<?php echo esc_attr($xpub); ?>"></td>
-    </tr></table>
+    <table class="form-table">
+      <tr>
+        <th><label for="weo_vendor_xpub">Vendor xpub</label></th>
+        <td><input type="text" class="regular-text code" name="weo_vendor_xpub" id="weo_vendor_xpub" value="<?php echo esc_attr($xpub); ?>"></td>
+      </tr>
+      <tr>
+        <th><label for="weo_vendor_payout_address">Payout-Adresse</label></th>
+        <td><input type="text" class="regular-text code" name="weo_vendor_payout_address" id="weo_vendor_payout_address" value="<?php echo esc_attr($payout); ?>"></td>
+      </tr>
+    </table>
     <?php
   }
 
@@ -26,6 +33,9 @@ class WEO_Vendor {
     if (!current_user_can('edit_user',$user_id)) return;
     if (isset($_POST['weo_vendor_xpub'])) {
       update_user_meta($user_id,'weo_vendor_xpub', weo_sanitize_xpub(wp_unslash($_POST['weo_vendor_xpub'])));
+    }
+    if (isset($_POST['weo_vendor_payout_address'])) {
+      update_user_meta($user_id,'weo_vendor_payout_address', weo_sanitize_btc_address(wp_unslash($_POST['weo_vendor_payout_address'])));
     }
   }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -42,3 +42,8 @@ function weo_sanitize_xpub($x) {
   }
   return $x;
 }
+
+function weo_sanitize_btc_address($addr) {
+  $addr = trim($addr);
+  return sanitize_text_field($addr);
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -8,8 +8,11 @@ function weo_get_option($key, $default = '') {
 
 function weo_api_post($endpoint, $body = []) {
   $base = rtrim(weo_get_option('api_base'), '/');
+  $key  = weo_get_option('api_key','');
+  $headers = ['Content-Type'=>'application/json'];
+  if ($key) $headers['x-api-key'] = $key;
   $resp = wp_remote_post("$base$endpoint", [
-    'headers' => ['Content-Type'=>'application/json'],
+    'headers' => $headers,
     'timeout' => 20,
     'body'    => wp_json_encode($body),
   ]);
@@ -21,7 +24,9 @@ function weo_api_post($endpoint, $body = []) {
 
 function weo_api_get($endpoint) {
   $base = rtrim(weo_get_option('api_base'), '/');
-  $resp = wp_remote_get("$base$endpoint", ['timeout'=>20]);
+  $key  = weo_get_option('api_key','');
+  $headers = $key ? ['x-api-key'=>$key] : [];
+  $resp = wp_remote_get("$base$endpoint", ['timeout'=>20,'headers'=>$headers]);
   if (is_wp_error($resp)) return $resp;
   $code = wp_remote_retrieve_response_code($resp);
   $json = json_decode(wp_remote_retrieve_body($resp), true);

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -35,15 +35,108 @@ function weo_api_get($endpoint) {
 
 function weo_sanitize_xpub($x) {
   $x = trim($x);
-  // Basic allowlist: Base58 or xpub/ypub/zpub/vpub etc., also xpub-like descriptors.
-  if (!preg_match('#^[xyzv]pub[a-km-zA-HJ-NP-Z1-9]+$#', $x) && !preg_match('#^(tpub|upub|vpub|Zpub|Vpub|Ypub)[a-km-zA-HJ-NP-Z1-9]+$#', $x)) {
-    // allow slip132 variants; keep loose for MVP
-    return $x; // we keep it permissive, validate server-side
-  }
-  return $x;
+  return preg_replace('/[^A-Za-z0-9]/','',$x);
 }
 
 function weo_sanitize_btc_address($addr) {
   $addr = trim($addr);
   return sanitize_text_field($addr);
+}
+
+// ---- Validation helpers ----
+
+function weo_normalize_xpub($xpub, $network = 'main') {
+  $xpub = weo_sanitize_xpub($xpub);
+  if (!$xpub) return new WP_Error('weo_xpub','xpub missing');
+
+  $vers = [
+    '0488b21e'=>['net'=>'main','dest'=>'0488b21e'], // xpub
+    '049d7cb2'=>['net'=>'main','dest'=>'0488b21e'], // ypub
+    '04b24746'=>['net'=>'main','dest'=>'0488b21e'], // zpub
+    '0295b43f'=>['net'=>'main','dest'=>'0488b21e'], // Ypub
+    '02aa7ed3'=>['net'=>'main','dest'=>'0488b21e'], // Zpub
+    '043587cf'=>['net'=>'test','dest'=>'043587cf'], // tpub
+    '044a5262'=>['net'=>'test','dest'=>'043587cf'], // upub
+    '045f1cf6'=>['net'=>'test','dest'=>'043587cf'], // vpub
+    '024289ef'=>['net'=>'test','dest'=>'043587cf'], // Upub
+    '02575483'=>['net'=>'test','dest'=>'043587cf'], // Vpub
+  ];
+
+  $hex = weo_base58check_decode($xpub);
+  if ($hex === false) return new WP_Error('weo_xpub','invalid base58');
+  $prefix = substr($hex,0,8);
+  $payload = substr($hex,8);
+  if (!isset($vers[$prefix])) return new WP_Error('weo_xpub','unknown prefix');
+  $info = $vers[$prefix];
+  if ($info['net'] !== $network) return new WP_Error('weo_xpub','wrong network');
+  $norm_hex = $info['dest'] . $payload;
+  return weo_base58check_encode($norm_hex);
+}
+
+function weo_validate_btc_address($addr, $network = 'main') {
+  $addr = weo_sanitize_btc_address($addr);
+  $hrp = $network === 'main' ? 'bc1' : 'tb1';
+  if (!preg_match('#^'.preg_quote($hrp,'#').'[0-9ac-hj-np-z]{8,87}$#i', $addr)) return false;
+  return true;
+}
+
+function weo_validate_amount($sats, $min = 1, $max = 2100000000000000) {
+  if (!is_numeric($sats)) return false;
+  $sats = intval($sats);
+  return ($sats >= $min && $sats <= $max);
+}
+
+function weo_sanitize_order_id($id) {
+  $id = sanitize_text_field($id);
+  return preg_match('/^[A-Za-z0-9_-]{1,32}$/',$id) ? $id : '';
+}
+
+// ---- Base58Check helpers ----
+
+function weo_base58check_decode($b58) {
+  $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  $num = '0';
+  for ($i=0; $i<strlen($b58); $i++) {
+    $p = strpos($alphabet, $b58[$i]);
+    if ($p === false) return false;
+    $num = bcadd(bcmul($num,'58'), (string)$p);
+  }
+  $hex = '';
+  while (bccomp($num,'0') > 0) {
+    $rem = bcmod($num,'16');
+    $num = bcdiv($num,'16',0);
+    $hex = dechex($rem) . $hex;
+  }
+  if (strlen($hex)%2) $hex = '0'.$hex;
+  $bin = hex2bin($hex);
+  $pad = 0;
+  for ($i=0; $i<strlen($b58) && $b58[$i]=='1'; $i++) $pad++;
+  $bin = str_repeat("\x00", $pad) . $bin;
+  $data = substr($bin,0,-4);
+  $checksum = substr($bin,-4);
+  $hash = substr(hash('sha256', hex2bin(hash('sha256',$data)), true),0,4);
+  if ($checksum !== $hash) return false;
+  return bin2hex($data);
+}
+
+function weo_base58check_encode($hex) {
+  $data = hex2bin($hex);
+  $checksum = substr(hash('sha256', hex2bin(hash('sha256',$data)), true),0,4);
+  $bin = $data . $checksum;
+  $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  $num = '0';
+  $bytes = unpack('C*', $bin);
+  foreach ($bytes as $b) {
+    $num = bcadd(bcmul($num,'256'), (string)$b);
+  }
+  $res = '';
+  while (bccomp($num,'0') > 0) {
+    $rem = bcmod($num,'58');
+    $num = bcdiv($num,'58',0);
+    $res = $alphabet[(int)$rem] . $res;
+  }
+  foreach ($bytes as $b) {
+    if ($b === 0) $res = '1'.$res; else break;
+  }
+  return $res;
 }

--- a/python-api/api.py
+++ b/python-api/api.py
@@ -13,7 +13,8 @@ BTC_CORE_USER    = os.getenv("BTC_CORE_USER", "")
 BTC_CORE_PASS    = os.getenv("BTC_CORE_PASS", "")
 BTC_CORE_WALLET  = os.getenv("BTC_CORE_WALLET", "escrowwatch")
 PORT             = int(os.getenv("PORT", "8080"))
-API_KEY_EXPECTED = os.getenv("API_KEY", "")
+API_KEYS         = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()}
+API_KEY_REVOKED  = {k.strip() for k in os.getenv("API_KEY_REVOKED", "").split(",") if k.strip()}
 ALLOW_ORIGINS    = [o.strip() for o in os.getenv("ALLOW_ORIGINS","*").split(",") if o.strip()]
 WOO_CALLBACK_URL = os.getenv("WOO_CALLBACK_URL", "")
 WOO_HMAC_SECRET  = os.getenv("WOO_HMAC_SECRET", "")
@@ -30,8 +31,9 @@ app.add_middleware(
 
 # ---- Simple API-Key dependency (optional) ----
 def require_api_key(x_api_key: Optional[str] = Header(None)):
-    if API_KEY_EXPECTED and x_api_key != API_KEY_EXPECTED:
-        raise HTTPException(status_code=401, detail="missing/invalid api key")
+    if API_KEYS:
+        if not x_api_key or x_api_key not in API_KEYS or x_api_key in API_KEY_REVOKED:
+            raise HTTPException(status_code=401, detail="missing/invalid api key")
 
 # ---- Bitcoin Core RPC ----
 def rpc(method: str, params: List[Any] = None) -> Any:

--- a/python-api/api.py
+++ b/python-api/api.py
@@ -15,7 +15,11 @@ BTC_CORE_WALLET  = os.getenv("BTC_CORE_WALLET", "escrowwatch")
 PORT             = int(os.getenv("PORT", "8080"))
 API_KEYS         = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()}
 API_KEY_REVOKED  = {k.strip() for k in os.getenv("API_KEY_REVOKED", "").split(",") if k.strip()}
-ALLOW_ORIGINS    = [o.strip() for o in os.getenv("ALLOW_ORIGINS","*").split(",") if o.strip()]
+
+_origins_env = os.getenv("ALLOW_ORIGINS")
+if not _origins_env:
+    raise RuntimeError("ALLOW_ORIGINS env var required")
+ALLOW_ORIGINS    = [o.strip() for o in _origins_env.split(",") if o.strip()]
 WOO_CALLBACK_URL = os.getenv("WOO_CALLBACK_URL", "")
 WOO_HMAC_SECRET  = os.getenv("WOO_HMAC_SECRET", "")
 
@@ -23,7 +27,7 @@ WOO_HMAC_SECRET  = os.getenv("WOO_HMAC_SECRET", "")
 app = FastAPI(title="Escrow API (2-of-3 P2WSH, PSBT)")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=ALLOW_ORIGINS if ALLOW_ORIGINS != ["*"] else ["*"],
+    allow_origins=ALLOW_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/python-api/api.py
+++ b/python-api/api.py
@@ -1,4 +1,4 @@
-import os, json, hmac, hashlib
+import os, json, hmac, hashlib, time
 from typing import Dict, Any, List, Optional
 from fastapi import FastAPI, HTTPException, Header, Depends
 from fastapi.middleware.cors import CORSMiddleware
@@ -103,11 +103,13 @@ def woo_callback(payload: Dict[str, Any]):
     if not (WOO_CALLBACK_URL and WOO_HMAC_SECRET):
         return
     body = json.dumps(payload, separators=(",",":")).encode()
-    sig  = hmac.new(WOO_HMAC_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    ts   = str(int(time.time()))
+    sig  = hmac.new(WOO_HMAC_SECRET.encode(), ts.encode() + body, hashlib.sha256).hexdigest()
     try:
         requests.post(WOO_CALLBACK_URL, data=body, headers={
             "content-type":"application/json",
-            "x-weo-sign": sig
+            "x-weo-sign": sig,
+            "x-weo-ts": ts
         }, timeout=10)
     except Exception:
         pass

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -62,6 +62,19 @@ def get_order(order_id: str) -> Optional[Dict[str, Any]]:
     return dict(row) if row else None
 
 
+def get_partials(order_id: str) -> List[str]:
+    conn = get_conn()
+    cur = conn.execute("SELECT partials FROM orders WHERE order_id=?", (order_id,))
+    row = cur.fetchone()
+    conn.close()
+    if not row or not row["partials"]:
+        return []
+    try:
+        return json.loads(row["partials"])
+    except Exception:
+        return []
+
+
 def update_state(order_id: str, state: str):
     conn = get_conn()
     conn.execute("UPDATE orders SET state=? WHERE order_id=?", (state, order_id))

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -151,3 +151,15 @@ def count_pending_signatures() -> int:
             pending += 2 - len(parts)
     return pending
 
+
+def list_orders_by_states(states: List[str]) -> List[Dict[str, Any]]:
+    conn = get_conn()
+    qmarks = ",".join(["?"] * len(states))
+    cur = conn.execute(
+        f"SELECT * FROM orders WHERE state IN ({qmarks})",
+        states,
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -1,0 +1,99 @@
+import os, sqlite3, time, json
+from typing import Any, Dict, List, Optional
+
+DB_PATH = os.getenv("ORDERS_DB", "orders.sqlite")
+
+
+def get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orders (
+            order_id TEXT PRIMARY KEY,
+            descriptor TEXT,
+            index INTEGER,
+            min_conf INTEGER,
+            label TEXT,
+            created_at INTEGER,
+            state TEXT,
+            funding_txid TEXT,
+            vout INTEGER,
+            confirmations INTEGER,
+            partials TEXT,
+            last_webhook_ts INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def upsert_order(order_id: str, descriptor: str, index: int, min_conf: int, label: str):
+    conn = get_conn()
+    now = int(time.time())
+    conn.execute(
+        """
+        INSERT INTO orders(order_id, descriptor, index, min_conf, label, created_at, state)
+        VALUES(?,?,?,?,?,?,?)
+        ON CONFLICT(order_id) DO UPDATE SET
+            descriptor=excluded.descriptor,
+            index=excluded.index,
+            min_conf=excluded.min_conf,
+            label=excluded.label
+        """,
+        (order_id, descriptor, index, min_conf, label, now, "awaiting_deposit"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_order(order_id: str) -> Optional[Dict[str, Any]]:
+    conn = get_conn()
+    cur = conn.execute("SELECT * FROM orders WHERE order_id=?", (order_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_state(order_id: str, state: str):
+    conn = get_conn()
+    conn.execute("UPDATE orders SET state=? WHERE order_id=?", (state, order_id))
+    conn.commit()
+    conn.close()
+
+
+def save_partials(order_id: str, partials: List[str]):
+    conn = get_conn()
+    conn.execute(
+        "UPDATE orders SET partials=? WHERE order_id=?",
+        (json.dumps(partials), order_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def update_funding(order_id: str, txid: str, vout: int, confirmations: int):
+    conn = get_conn()
+    conn.execute(
+        "UPDATE orders SET funding_txid=?, vout=?, confirmations=? WHERE order_id=?",
+        (txid, vout, confirmations, order_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def set_last_webhook_ts(order_id: str, ts: int):
+    conn = get_conn()
+    conn.execute(
+        "UPDATE orders SET last_webhook_ts=? WHERE order_id=?",
+        (ts, order_id),
+    )
+    conn.commit()
+    conn.close()

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -135,3 +135,19 @@ def set_payout_txid(order_id: str, txid: str):
     conn.commit()
     conn.close()
 
+
+def count_pending_signatures() -> int:
+    conn = get_conn()
+    cur = conn.execute("SELECT partials FROM orders WHERE state='signing'")
+    rows = cur.fetchall()
+    conn.close()
+    pending = 0
+    for r in rows:
+        try:
+            parts = json.loads(r["partials"]) if r["partials"] else []
+        except Exception:
+            parts = []
+        if len(parts) < 2:
+            pending += 2 - len(parts)
+    return pending
+

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -75,9 +75,19 @@ def get_partials(order_id: str) -> List[str]:
         return []
 
 
-def update_state(order_id: str, state: str):
+def update_state(order_id: str, state: str, confirmations: Optional[int] = None):
     conn = get_conn()
-    conn.execute("UPDATE orders SET state=? WHERE order_id=?", (state, order_id))
+    now = int(time.time())
+    if confirmations is not None:
+        conn.execute(
+            "UPDATE orders SET state=?, confirmations=?, created_at=? WHERE order_id=?",
+            (state, confirmations, now, order_id),
+        )
+    else:
+        conn.execute(
+            "UPDATE orders SET state=?, created_at=? WHERE order_id=?",
+            (state, now, order_id),
+        )
     conn.commit()
     conn.close()
 

--- a/python-api/db.py
+++ b/python-api/db.py
@@ -27,10 +27,14 @@ def init_db():
             vout INTEGER,
             confirmations INTEGER,
             partials TEXT,
-            last_webhook_ts INTEGER
+            last_webhook_ts INTEGER,
+            payout_txid TEXT
         )
-        """
+        """,
     )
+    cols = [r[1] for r in cur.execute("PRAGMA table_info(orders)")]
+    if "payout_txid" not in cols:
+        cur.execute("ALTER TABLE orders ADD COLUMN payout_txid TEXT")
     conn.commit()
     conn.close()
 
@@ -120,3 +124,14 @@ def set_last_webhook_ts(order_id: str, ts: int):
     )
     conn.commit()
     conn.close()
+
+
+def set_payout_txid(order_id: str, txid: str):
+    conn = get_conn()
+    conn.execute(
+        "UPDATE orders SET payout_txid=? WHERE order_id=?",
+        (txid, order_id),
+    )
+    conn.commit()
+    conn.close()
+

--- a/templates/dokan-treuhand.php
+++ b/templates/dokan-treuhand.php
@@ -1,0 +1,15 @@
+<?php
+if (!defined('ABSPATH')) exit;
+?>
+<form method="post" class="dokan-form">
+  <?php wp_nonce_field('weo_dokan_xpub'); ?>
+  <div class="dokan-form-group">
+    <label for="weo_vendor_xpub" class="dokan-form-label"><?php esc_html_e('Vendor xpub','weo'); ?></label>
+    <input type="text" class="dokan-form-control" name="weo_vendor_xpub" id="weo_vendor_xpub" value="<?php echo esc_attr($xpub); ?>">
+  </div>
+  <div class="dokan-form-group">
+    <button type="submit" class="dokan-btn dokan-btn-theme">
+      <?php esc_html_e('Speichern','weo'); ?>
+    </button>
+  </div>
+</form>

--- a/templates/dokan-treuhand.php
+++ b/templates/dokan-treuhand.php
@@ -8,6 +8,10 @@ if (!defined('ABSPATH')) exit;
     <input type="text" class="dokan-form-control" name="weo_vendor_xpub" id="weo_vendor_xpub" value="<?php echo esc_attr($xpub); ?>">
   </div>
   <div class="dokan-form-group">
+    <label for="weo_vendor_payout_address" class="dokan-form-label"><?php esc_html_e('Payout-Adresse','weo'); ?></label>
+    <input type="text" class="dokan-form-control" name="weo_vendor_payout_address" id="weo_vendor_payout_address" value="<?php echo esc_attr($payout); ?>">
+  </div>
+  <div class="dokan-form-group">
     <button type="submit" class="dokan-btn dokan-btn-theme">
       <?php esc_html_e('Speichern','weo'); ?>
     </button>

--- a/woo-escrow-onchain.php
+++ b/woo-escrow-onchain.php
@@ -16,6 +16,7 @@ define('WEO_OPT', 'weo_options'); // Optionen-Array
 require_once WEO_DIR.'includes/helpers.php';
 require_once WEO_DIR.'includes/class-escrow-settings.php';
 require_once WEO_DIR.'includes/class-escrow-vendor.php';
+require_once WEO_DIR.'includes/class-escrow-dokan.php';
 require_once WEO_DIR.'includes/class-escrow-checkout.php';
 require_once WEO_DIR.'includes/class-escrow-order.php';
 require_once WEO_DIR.'includes/class-escrow-rest.php';
@@ -24,6 +25,7 @@ add_action('plugins_loaded', function() {
   if (!class_exists('WooCommerce')) return;
   new WEO_Settings();
   new WEO_Vendor();
+  if (function_exists('dokan')) new WEO_Dokan();
   new WEO_Checkout();
   new WEO_Order();
   new WEO_REST();


### PR DESCRIPTION
# Woo Escrow On-Chain

This project links a WooCommerce plugin with a Python FastAPI service to handle Bitcoin multisig escrow.

## Vendor setup

Dokan sellers can configure their escrow xpub under **Treuhand Service** in the vendor dashboard.

## API key management

The API reads a comma-separated list of valid keys from the `API_KEYS` environment variable. You can revoke individual keys by listing them in `API_KEY_REVOKED`.

The WooCommerce plugin holds a single active key in its settings and sends it with every request using the `x-api-key` header.

### Key rotation
1. Deploy a new key and add it to `API_KEYS` on the API server.
2. Update the plugin setting with the new key.
3. Once clients have switched, remove the old key from `API_KEYS` or move it to `API_KEY_REVOKED`.

## Webhook security

When the API calls back into WooCommerce it signs the JSON body together with a Unix timestamp. The plugin stores a shared HMAC secret and verifies each request:

- `x-weo-ts` contains the timestamp (±5 minutes allowed)
- `x-weo-sign` is `HMAC_SHA256(secret, ts + body)`
- Requests with missing, stale, or mismatched signatures are rejected with `401`

Callbacks are delivered asynchronously with retry and exponential backoff. Configure `WEBHOOK_RETRIES` for the number of attempts
and `WEBHOOK_BACKOFF` as the multiplier between retries (defaults: 3 retries, backoff 2). Successful final notifications record a
timestamp in the `last_webhook_ts` column to prevent duplicate sends.

## CORS configuration

The API enforces a strict origin whitelist. Set the `ALLOW_ORIGINS` environment
variable to a comma-separated list of permitted shop domains.

Example:

```bash
# production
ALLOW_ORIGINS=https://shop.example.com

# staging
ALLOW_ORIGINS=https://shop-staging.example.com
```

After updating the value, redeploy the API so the new origins take effect.

## Prometheus metrics

The API exposes metrics under `/metrics` in the Prometheus exposition format. The following metrics are available:

- `rpc_duration_seconds` – histogram of Bitcoin Core RPC latency, labelled by `method`
- `webhook_total` – counter for webhook deliveries with label `status` (`success` or `error`)
- `pending_signatures` – gauge for the number of missing PSBT signatures across orders
- `broadcast_fail_total` – counter for failed transaction broadcasts
- `stuck_orders_total` – counter labelled by `state` for orders that exceed `STUCK_ORDER_HOURS`

Example scrape configuration:

```yaml
scrape_configs:
  - job_name: escrow_api
    static_configs:
      - targets: ['api.example.com:8080']
```

### Alerting

The API periodically checks orders in `awaiting_deposit` and `signing`. When an order remains
in one of these states longer than `STUCK_ORDER_HOURS` (default 24 h), the `stuck_orders_total{state}`
counter is incremented and a warning is logged. Configure `STUCK_CHECK_INTERVAL` (seconds) to tune the
scan frequency. Optionally set `SENTRY_DSN` to forward warnings to Sentry.

Alertmanager should fire when either `broadcast_fail_total` or `stuck_orders_total` increases. A simple rule:

```yaml
alerts:
  - alert: EscrowBroadcastFailures
    expr: increase(broadcast_fail_total[5m]) > 0
  - alert: EscrowStuckOrders
    expr: increase(stuck_orders_total[1h]) > 0
``` 

These alerts signal that transactions failed to broadcast or orders have stalled and require manual intervention.