### PR TITLE
Add dashboard hint for PSBT access

### DIFF
--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -113,6 +113,7 @@ class WEO_Order {
     echo '<li>'.esc_html__('Verkäufer markiert Versand, Käufer bestätigt den Empfang.', 'weo').'</li>';
     echo '<li>'.esc_html__('Beide Parteien erstellen eine PSBT, signieren sie und laden sie hoch.', 'weo').'</li>';
     echo '</ol>';
+    echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Service" erneut abgerufen und signiert werden.', 'weo').'</p>';
     $doc_url = esc_url(plugins_url('docs/woo-user-guide.md', WEO_PLUGIN_FILE));
     echo '<p><a href="'.$doc_url.'" target="_blank" rel="noopener">'.esc_html__('Zur ausführlichen Anleitung', 'weo').'</a></p>';
 

--- a/templates/dokan-treuhand-orders.php
+++ b/templates/dokan-treuhand-orders.php
@@ -2,6 +2,7 @@
 if (!defined('ABSPATH')) exit;
 ?>
 <?php if (!empty($psbt_notice)) echo $psbt_notice; ?>
+<p><?php esc_html_e('PSBTs können jederzeit über diesen Bereich "Treuhand Service" im Dokan-Dashboard erneut abgerufen und signiert werden.','weo'); ?></p>
 <?php if (!empty($orders)) : ?>
   <?php foreach ($orders as $o) : ?>
     <div class="weo-escrow-order">


### PR DESCRIPTION
## Summary
- remind users that PSBTs can be reopened and signed later via Dokan's "Treuhand Service" dashboard
- mirror the PSBT dashboard hint on the vendor order list for consistency

## Testing
- `composer install`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b48645faf4832ea2c3092450807ccb