### PR TITLE
Load gateway after WooCommerce initializes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project links a WooCommerce plugin with a Python FastAPI service to handle 
 
 ## Vendor setup
 
-Dokan sellers can configure their escrow xpub under **Treuhand Service** in the vendor dashboard.
+Dokan sellers can configure their escrow xpub under **Treuhand Overview** in the vendor dashboard.
 
 ## API key management
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project links a WooCommerce plugin with a Python FastAPI service to handle 
 
 ## Vendor setup
 
-Dokan sellers can configure their escrow xpub under **Treuhand Overview** in the vendor dashboard.
+Dokan sellers can create a page (e.g., `/escrow-settings/`) containing the `[weo_treuhand]` shortcode. The Dokan dashboard adds a **Treuhand Service** menu item linking to that page for vendors to manage their escrow settings and orders.
 
 ## API key management
 

--- a/includes/class-escrow-admin.php
+++ b/includes/class-escrow-admin.php
@@ -1,6 +1,11 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+// Avoid redeclaring the admin helper if another copy of the plugin loaded it.
+if (class_exists('WEO_Admin')) {
+  return;
+}
+
 class WEO_Admin {
   public function __construct() {
     add_action('admin_menu', [$this, 'menu']);

--- a/includes/class-escrow-admin.php
+++ b/includes/class-escrow-admin.php
@@ -10,7 +10,7 @@ class WEO_Admin {
 
   public function menu() {
     add_submenu_page(
-      'woocommerce',
+      'weo-treuhand',
       'Escrows',
       'Escrows',
       'manage_woocommerce',
@@ -19,7 +19,7 @@ class WEO_Admin {
     );
 
     add_submenu_page(
-      'woocommerce',
+      'weo-treuhand',
       'Disputes',
       'Disputes',
       'manage_woocommerce',

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -10,6 +10,7 @@ class WEO_Dokan {
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
     add_filter('dokan_query_vars', [$this,'query_vars']);
+    add_action('init', [$this,'add_endpoints']);
   }
 
   public function nav($urls) {
@@ -240,6 +241,11 @@ class WEO_Dokan {
     $vars[] = 'weo-treuhand-orders';
     $vars[] = 'weo-treuhand';
     return $vars;
+  }
+
+  public function add_endpoints() {
+    add_rewrite_endpoint('weo-treuhand-orders', EP_ROOT | EP_PAGES);
+    add_rewrite_endpoint('weo-treuhand', EP_ROOT | EP_PAGES);
   }
 
   /** Fallback – trag hier eine Vendor-Payout-Adresse ein, falls nicht separat gepflegt */

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -5,10 +5,21 @@ class WEO_Dokan {
   public function __construct() {
     add_action('init', [$this,'handle_treuhand_settings_post'], 0);
     add_shortcode('weo_treuhand', [$this,'render_treuhand_shortcode']);
+    add_filter('dokan_get_dashboard_nav', [$this,'dashboard_nav']);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
+  }
+
+  public function dashboard_nav($navs) {
+    $navs['weo_treuhand'] = [
+      'title' => __('Treuhand Service','weo'),
+      'icon'  => '<i class="fas fa-handshake"></i>',
+      'url'   => home_url('/escrow-settings/'),
+      'pos'   => 55,
+    ];
+    return $navs;
   }
 
   public function handle_treuhand_settings_post() {

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -9,6 +9,7 @@ class WEO_Dokan {
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
+    add_filter('dokan_query_vars', [$this,'query_vars']);
   }
 
   public function nav($urls) {
@@ -233,6 +234,12 @@ class WEO_Dokan {
 
   public function maybe_hide_add_to_cart($html, $product, $args) {
     return $product->is_purchasable() ? $html : '';
+  }
+
+  public function query_vars($vars) {
+    $vars[] = 'weo-treuhand-orders';
+    $vars[] = 'weo-treuhand';
+    return $vars;
   }
 
   /** Fallback – trag hier eine Vendor-Payout-Adresse ein, falls nicht separat gepflegt */

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -10,7 +10,8 @@ class WEO_Dokan {
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
   }
   public function render_treuhand_section() {
-    if (function_exists('dokan_get_current_endpoint') && dokan_get_current_endpoint() !== 'orders') {
+    if (!function_exists('dokan_get_current_endpoint') ||
+        dokan_get_current_endpoint() !== 'orders') {
       return;
     }
     if (!current_user_can('vendor') && !current_user_can('seller')) {

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -114,7 +114,11 @@ class WEO_Dokan {
           }
         }
       } elseif (isset($_POST['weo_vendor_xpub'])) {
-        check_admin_referer('weo_dokan_xpub');
+        if (!wp_verify_nonce($_POST['_wpnonce'] ?? '', 'weo_dokan_xpub')) {
+          dokan_add_notice(__('Ungültiger Sicherheits-Token','weo'),'error');
+          wp_safe_redirect(dokan_get_navigation_url('weo-treuhand-orders'));
+          exit;
+        }
         $xpub_raw = wp_unslash($_POST['weo_vendor_xpub']);
         $xpub     = $xpub_raw !== '' ? weo_normalize_xpub($xpub_raw) : '';
         $payout   = isset($_POST['weo_payout_address']) ? wp_unslash($_POST['weo_payout_address']) : '';
@@ -128,6 +132,8 @@ class WEO_Dokan {
           if ($escrow) update_user_meta($user_id,'weo_vendor_escrow_enabled','1');
           else delete_user_meta($user_id,'weo_vendor_escrow_enabled');
           dokan_add_notice(__('Escrow-Daten gespeichert','weo'),'success');
+          wp_safe_redirect(dokan_get_navigation_url('weo-treuhand-orders'));
+          exit;
         }
       }
     }

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -6,7 +6,7 @@ class WEO_Dokan {
     add_filter('dokan_get_dashboard_nav', [$this,'nav']);
     add_filter('dokan_query_vars', [$this,'query_vars']);
     add_action('dokan_load_custom_template', [$this,'page']);
-    add_action('template_redirect', [$this,'handle_treuhand_settings_post']);
+    add_action('init', [$this,'handle_treuhand_settings_post'], 0);
     add_action('init', [$this,'add_endpoints']);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
@@ -37,7 +37,6 @@ class WEO_Dokan {
   }
 
   public function handle_treuhand_settings_post() {
-    if (!function_exists('dokan_get_navigation_url') || !function_exists('dokan_add_notice')) return;
     if ('POST' !== $_SERVER['REQUEST_METHOD']) return;
     if (!isset($_POST['weo_vendor_xpub']) && !isset($_POST['weo_payout_address']) && !isset($_POST['weo_vendor_escrow_enabled'])) return;
     if (!current_user_can('vendor') && !current_user_can('seller')) return;

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -3,13 +3,17 @@ if (!defined('ABSPATH')) exit;
 
 class WEO_Dokan {
   public function __construct() {
-    add_action('dokan_orders_content_inside_after', [$this,'render_treuhand_section']);
+    add_action('dokan_dashboard_content_after', [$this,'render_treuhand_section']);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
   }
   public function render_treuhand_section() {
+    $ep = function_exists('dokan_get_current_endpoint') ? dokan_get_current_endpoint() : (function_exists('get_query_var') ? get_query_var('orders') : '');
+    if ($ep !== 'orders') {
+      return;
+    }
     if (!current_user_can('vendor') && !current_user_can('seller')) {
       dokan_add_notice(__('Keine Berechtigung','weo'),'error');
       return;

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -3,15 +3,40 @@ if (!defined('ABSPATH')) exit;
 
 class WEO_Dokan {
   public function __construct() {
-    add_action('dokan_dashboard_content_after', [$this,'render_treuhand_section'], 10, 0);
+    add_filter('dokan_get_dashboard_nav', [$this,'nav']);
+    add_filter('dokan_query_vars', [$this,'query_vars']);
+    add_action('dokan_load_custom_template', [$this,'page']);
+    add_action('init', [$this,'add_endpoints']);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
   }
-  public function render_treuhand_section() {
-    if (!function_exists('dokan_get_current_endpoint') ||
-        dokan_get_current_endpoint() !== 'orders') {
+
+  public function nav($urls) {
+    if (!current_user_can('vendor') && !current_user_can('seller')) return $urls;
+    $urls['weo-treuhand-orders'] = [
+      'title' => __('Treuhand Overview','weo'),
+      'icon'  => '<i class="fas fa-handshake"></i>',
+      'url'   => dokan_get_navigation_url('weo-treuhand-orders'),
+      'pos'   => 51,
+    ];
+    return $urls;
+  }
+
+  public function query_vars($vars) {
+    $vars[] = 'weo-treuhand-orders';
+    $vars[] = 'weo-treuhand';
+    return $vars;
+  }
+
+  public function add_endpoints() {
+    add_rewrite_endpoint('weo-treuhand-orders', EP_ROOT | EP_PAGES);
+    add_rewrite_endpoint('weo-treuhand', EP_ROOT | EP_PAGES);
+  }
+
+  public function page($query_vars) {
+    if (!isset($query_vars['weo-treuhand-orders']) && !isset($query_vars['weo-treuhand'])) {
       return;
     }
     if (!current_user_can('vendor') && !current_user_can('seller')) {

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -3,15 +3,14 @@ if (!defined('ABSPATH')) exit;
 
 class WEO_Dokan {
   public function __construct() {
-    add_action('dokan_dashboard_content_after', [$this,'render_treuhand_section']);
+    add_action('dokan_dashboard_content_after', [$this,'render_treuhand_section'], 10, 0);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);
     add_filter('woocommerce_loop_add_to_cart_link', [$this,'maybe_hide_add_to_cart'], 10, 3);
   }
   public function render_treuhand_section() {
-    $ep = function_exists('dokan_get_current_endpoint') ? dokan_get_current_endpoint() : (function_exists('get_query_var') ? get_query_var('orders') : '');
-    if ($ep !== 'orders') {
+    if (function_exists('dokan_get_current_endpoint') && dokan_get_current_endpoint() !== 'orders') {
       return;
     }
     if (!current_user_can('vendor') && !current_user_can('seller')) {

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -60,8 +60,16 @@ class WEO_Dokan {
       $ok = false;
     }
     if ($ok) {
-      if ($xpub_raw !== '') update_user_meta($user_id,'weo_vendor_xpub',$xpub);
-      if ($payout) update_user_meta($user_id,'weo_payout_address', weo_sanitize_btc_address($payout));
+      if ($xpub_raw !== '') {
+        update_user_meta($user_id,'weo_vendor_xpub',$xpub);
+      } else {
+        delete_user_meta($user_id,'weo_vendor_xpub');
+      }
+      if ($payout !== '') {
+        update_user_meta($user_id,'weo_payout_address', weo_sanitize_btc_address($payout));
+      } else {
+        delete_user_meta($user_id,'weo_payout_address');
+      }
       if ($escrow) update_user_meta($user_id,'weo_vendor_escrow_enabled','1');
       else delete_user_meta($user_id,'weo_vendor_escrow_enabled');
       dokan_add_notice(__('Escrow-Daten gespeichert','weo'),'success');

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -37,6 +37,7 @@ class WEO_Dokan {
   }
 
   public function handle_treuhand_settings_post() {
+    if (!function_exists('dokan_get_navigation_url') || !function_exists('dokan_add_notice')) return;
     if ('POST' !== $_SERVER['REQUEST_METHOD']) return;
     if (!isset($_POST['weo_vendor_xpub']) && !isset($_POST['weo_payout_address']) && !isset($_POST['weo_vendor_escrow_enabled'])) return;
     if (!current_user_can('vendor') && !current_user_can('seller')) return;

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit;
 class WEO_Dokan {
   public function __construct() {
     add_filter('dokan_get_dashboard_nav', [$this,'nav']);
-    add_action('dokan_render_settings_content', [$this,'page']);
+    add_action('dokan_load_custom_template', [$this,'page']);
     add_action('dokan_product_edit_after_pricing', [$this,'product_field'], 10, 2);
     add_action('dokan_process_product_meta', [$this,'save_product_meta'], 10, 2);
     add_filter('woocommerce_is_purchasable', [$this,'is_purchasable'], 10, 2);

--- a/includes/class-escrow-dokan.php
+++ b/includes/class-escrow-dokan.php
@@ -115,14 +115,15 @@ class WEO_Dokan {
         }
       } elseif (isset($_POST['weo_vendor_xpub'])) {
         check_admin_referer('weo_dokan_xpub');
-        $xpub   = weo_normalize_xpub(wp_unslash($_POST['weo_vendor_xpub']));
-        $payout = isset($_POST['weo_payout_address']) ? wp_unslash($_POST['weo_payout_address']) : '';
-        $escrow = isset($_POST['weo_vendor_escrow_enabled']) ? '1' : '';
-        $ok = true;
-        if (is_wp_error($xpub)) { dokan_add_notice(__('Ungültiges xpub','weo'),'error'); $ok = false; }
+        $xpub_raw = wp_unslash($_POST['weo_vendor_xpub']);
+        $xpub     = $xpub_raw !== '' ? weo_normalize_xpub($xpub_raw) : '';
+        $payout   = isset($_POST['weo_payout_address']) ? wp_unslash($_POST['weo_payout_address']) : '';
+        $escrow   = isset($_POST['weo_vendor_escrow_enabled']) ? '1' : '';
+        $ok       = $xpub_raw === '' || !is_wp_error($xpub);
+        if ($xpub_raw !== '' && is_wp_error($xpub)) { dokan_add_notice(__('Ungültiges xpub','weo'),'error'); }
         if ($payout && !weo_validate_btc_address($payout)) { dokan_add_notice(__('Ungültige Adresse','weo'),'error'); $ok = false; }
         if ($ok) {
-          update_user_meta($user_id,'weo_vendor_xpub',$xpub);
+          if ($xpub_raw !== '') update_user_meta($user_id,'weo_vendor_xpub',$xpub);
           if ($payout) update_user_meta($user_id,'weo_payout_address', weo_sanitize_btc_address($payout));
           if ($escrow) update_user_meta($user_id,'weo_vendor_escrow_enabled','1');
           else delete_user_meta($user_id,'weo_vendor_escrow_enabled');

--- a/includes/class-escrow-notifications.php
+++ b/includes/class-escrow-notifications.php
@@ -18,7 +18,7 @@ class WEO_Notifications {
     $order = wc_get_order($order_id); if (!$order) return;
     $to = $order->get_billing_email();
     $subject = __('Bestellung versendet', 'weo');
-    $message = sprintf(__('Der Verkäufer hat Bestellung %s als versendet markiert. Bitte bestätige den Empfang im Dokan-Dashboard.', 'weo'), $order->get_order_number());
+    $message = sprintf(__('Der Verkäufer hat Bestellung %s als versendet markiert. Bitte bestätige den Empfang auf der Treuhand-Seite.', 'weo'), $order->get_order_number());
     self::send_mail($to, $subject, $message);
     $order->add_order_note(__('Verkäufer hat Versand markiert; Käufer benachrichtigt.', 'weo'), true);
   }
@@ -29,7 +29,7 @@ class WEO_Notifications {
     $vendor = get_userdata($vendor_id); if (!$vendor) return;
     $to = $vendor->user_email;
     $subject = __('Empfang bestätigt', 'weo');
-    $message = sprintf(__('Der Käufer hat Bestellung %s als erhalten markiert. Bitte signiere die PSBT im Dokan-Dashboard.', 'weo'), $order->get_order_number());
+    $message = sprintf(__('Der Käufer hat Bestellung %s als erhalten markiert. Bitte signiere die PSBT auf der Treuhand-Seite.', 'weo'), $order->get_order_number());
     self::send_mail($to, $subject, $message);
     $order->add_order_note(__('Käufer hat Empfang bestätigt; Verkäufer benachrichtigt.', 'weo'), true);
   }
@@ -42,12 +42,12 @@ class WEO_Notifications {
       $user = get_userdata($vendor_id); if (!$user) return;
       $to = $user->user_email;
       $subject = __('Käufer hat eine PSBT hochgeladen', 'weo');
-      $message = sprintf(__('Der Käufer hat eine signierte PSBT für Bestellung %s hochgeladen. Bitte prüfe und signiere im Dokan-Dashboard.', 'weo'), $order->get_order_number());
+      $message = sprintf(__('Der Käufer hat eine signierte PSBT für Bestellung %s hochgeladen. Bitte prüfe und signiere auf der Treuhand-Seite.', 'weo'), $order->get_order_number());
       $note = __('Käufer hat eine PSBT hochgeladen; Verkäufer benachrichtigt.', 'weo');
     } else {
       $to = $order->get_billing_email();
       $subject = __('Verkäufer hat eine PSBT hochgeladen', 'weo');
-      $message = sprintf(__('Der Verkäufer hat eine signierte PSBT für Bestellung %s hochgeladen. Bitte prüfe und signiere im Dokan-Dashboard.', 'weo'), $order->get_order_number());
+      $message = sprintf(__('Der Verkäufer hat eine signierte PSBT für Bestellung %s hochgeladen. Bitte prüfe und signiere auf der Treuhand-Seite.', 'weo'), $order->get_order_number());
       $note = __('Verkäufer hat eine PSBT hochgeladen; Käufer benachrichtigt.', 'weo');
     }
     self::send_mail($to, $subject, $message);
@@ -74,7 +74,7 @@ class WEO_Notifications {
     $vendor = get_userdata($vendor_id); if (!$vendor) return;
     $to = $vendor->user_email;
     $subject = __('Gebührenerhöhung angefordert', 'weo');
-    $message = sprintf(__('Für Bestellung %s wurde eine RBF-PSBT angefordert. Bitte signiere die neue PSBT im Dashboard.', 'weo'), $order->get_order_number());
+      $message = sprintf(__('Für Bestellung %s wurde eine RBF-PSBT angefordert. Bitte signiere die neue PSBT auf der Treuhand-Seite.', 'weo'), $order->get_order_number());
     self::send_mail($to, $subject, $message);
     $order->add_order_note(__('RBF angefordert; Verkäufer benachrichtigt.', 'weo'), true);
   }

--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -131,10 +131,9 @@ class WEO_Order {
     echo '<li>'.esc_html__('Verkäufer markiert Versand, Käufer bestätigt den Empfang.', 'weo').'</li>';
     echo '<li>'.esc_html__('Beide Parteien erstellen eine PSBT, signieren sie und laden sie hoch.', 'weo').'</li>';
     echo '</ol>';
-    echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Service" erneut abgerufen und signiert werden.', 'weo').'</p>';
+    echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Overview" erneut abgerufen und signiert werden.', 'weo').'</p>';
     if (function_exists('dokan_get_navigation_url')) {
-      $url = dokan_get_navigation_url('orders');
-      $dash_url = esc_url(rtrim($url, '/') . '/');
+      $dash_url = esc_url(dokan_get_navigation_url('weo-treuhand-orders'));
       echo '<p><a href="'.$dash_url.'" class="button">'.esc_html__('Zum Treuhand-Dashboard', 'weo').'</a></p>';
     }
     $doc_url = esc_url(plugins_url('docs/woo-user-guide.md', WEO_PLUGIN_FILE));

--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -134,7 +134,7 @@ class WEO_Order {
     echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Service" erneut abgerufen und signiert werden.', 'weo').'</p>';
     if (function_exists('dokan_get_navigation_url')) {
       $url = dokan_get_navigation_url('orders');
-      $dash_url = esc_url(rtrim($url, '/') . '/#weo-treuhand');
+      $dash_url = esc_url(rtrim($url, '/') . '/');
       echo '<p><a href="'.$dash_url.'" class="button">'.esc_html__('Zum Treuhand-Dashboard', 'weo').'</a></p>';
     }
     $doc_url = esc_url(plugins_url('docs/woo-user-guide.md', WEO_PLUGIN_FILE));

--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -133,7 +133,8 @@ class WEO_Order {
     echo '</ol>';
     echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Service" erneut abgerufen und signiert werden.', 'weo').'</p>';
     if (function_exists('dokan_get_navigation_url')) {
-      $dash_url = esc_url(dokan_get_navigation_url('weo-treuhand-orders'));
+      $url = dokan_get_navigation_url('orders');
+      $dash_url = esc_url(rtrim($url, '/') . '/#weo-treuhand');
       echo '<p><a href="'.$dash_url.'" class="button">'.esc_html__('Zum Treuhand-Dashboard', 'weo').'</a></p>';
     }
     $doc_url = esc_url(plugins_url('docs/woo-user-guide.md', WEO_PLUGIN_FILE));

--- a/includes/class-escrow-order.php
+++ b/includes/class-escrow-order.php
@@ -131,11 +131,7 @@ class WEO_Order {
     echo '<li>'.esc_html__('Verkäufer markiert Versand, Käufer bestätigt den Empfang.', 'weo').'</li>';
     echo '<li>'.esc_html__('Beide Parteien erstellen eine PSBT, signieren sie und laden sie hoch.', 'weo').'</li>';
     echo '</ol>';
-    echo '<p>'.esc_html__('Die PSBT kann jederzeit im Dokan-Dashboard unter "Treuhand Overview" erneut abgerufen und signiert werden.', 'weo').'</p>';
-    if (function_exists('dokan_get_navigation_url')) {
-      $dash_url = esc_url(dokan_get_navigation_url('weo-treuhand-orders'));
-      echo '<p><a href="'.$dash_url.'" class="button">'.esc_html__('Zum Treuhand-Dashboard', 'weo').'</a></p>';
-    }
+    echo '<p>'.esc_html__('Die PSBT kann jederzeit über die Treuhand-Seite erneut abgerufen und signiert werden.', 'weo').'</p>';
     $doc_url = esc_url(plugins_url('docs/woo-user-guide.md', WEO_PLUGIN_FILE));
     echo '<p><a href="'.$doc_url.'" target="_blank" rel="noopener">'.esc_html__('Zur ausführlichen Anleitung', 'weo').'</a></p>';
 

--- a/includes/class-escrow-settings.php
+++ b/includes/class-escrow-settings.php
@@ -33,7 +33,9 @@ class WEO_Settings {
   }
 
   public function menu() {
-    add_submenu_page('woocommerce', 'Escrow On-Chain', 'Escrow On-Chain', 'manage_woocommerce', 'weo', [$this,'render']);
+    add_menu_page('Treuhand', 'Treuhand', 'manage_woocommerce', 'weo-treuhand', [$this,'render'], 'dashicons-lock', 56);
+    add_submenu_page('weo-treuhand', 'Einstellungen', 'Einstellungen', 'manage_woocommerce', 'weo', [$this,'render']);
+    remove_submenu_page('weo-treuhand', 'weo-treuhand');
   }
 
   public function field_api() {

--- a/templates/dokan-treuhand-orders.php
+++ b/templates/dokan-treuhand-orders.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 ?>
 <?php if (!empty($psbt_notice)) echo $psbt_notice; ?>
-<p><?php esc_html_e('PSBTs können jederzeit über diesen Bereich "Treuhand Service" im Dokan-Dashboard erneut abgerufen und signiert werden.','weo'); ?></p>
+<p><?php esc_html_e('PSBTs können jederzeit über diesen Bereich "Treuhand Overview" im Dokan-Dashboard erneut abgerufen und signiert werden.','weo'); ?></p>
 <?php if (!empty($orders)) : ?>
   <?php foreach ($orders as $o) : ?>
     <div class="weo-escrow-order">

--- a/templates/dokan-treuhand-orders.php
+++ b/templates/dokan-treuhand-orders.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 ?>
 <?php if (!empty($psbt_notice)) echo $psbt_notice; ?>
-<p><?php esc_html_e('PSBTs können jederzeit über diesen Bereich "Treuhand Overview" im Dokan-Dashboard erneut abgerufen und signiert werden.','weo'); ?></p>
+<p><?php esc_html_e('PSBTs können jederzeit auf dieser Treuhand-Seite erneut abgerufen und signiert werden.','weo'); ?></p>
 <?php if (!empty($orders)) : ?>
   <?php foreach ($orders as $o) : ?>
     <div class="weo-escrow-order">

--- a/tests/php/GatewayFlowTest.php
+++ b/tests/php/GatewayFlowTest.php
@@ -143,7 +143,7 @@ class GatewayFlowTest extends TestCase {
         $html = ob_get_clean();
         $this->assertStringContainsString('PSBT kann jederzeit im Dokan-Dashboard', $html);
         $this->assertStringContainsString('Zum Treuhand-Dashboard', $html);
-        $this->assertStringContainsString('/dashboard/orders/', $html);
+        $this->assertStringContainsString('/weo-treuhand-orders', $html);
         $this->assertStringContainsString('txid123', $html);
     }
 

--- a/tests/php/GatewayFlowTest.php
+++ b/tests/php/GatewayFlowTest.php
@@ -143,7 +143,7 @@ class GatewayFlowTest extends TestCase {
         $html = ob_get_clean();
         $this->assertStringContainsString('PSBT kann jederzeit im Dokan-Dashboard', $html);
         $this->assertStringContainsString('Zum Treuhand-Dashboard', $html);
-        $this->assertStringContainsString('/weo-treuhand-orders', $html);
+        $this->assertStringContainsString('/orders/#weo-treuhand', $html);
         $this->assertStringContainsString('txid123', $html);
     }
 

--- a/tests/php/GatewayFlowTest.php
+++ b/tests/php/GatewayFlowTest.php
@@ -143,7 +143,7 @@ class GatewayFlowTest extends TestCase {
         $html = ob_get_clean();
         $this->assertStringContainsString('PSBT kann jederzeit im Dokan-Dashboard', $html);
         $this->assertStringContainsString('Zum Treuhand-Dashboard', $html);
-        $this->assertStringContainsString('/orders/#weo-treuhand', $html);
+        $this->assertStringContainsString('/dashboard/orders/', $html);
         $this->assertStringContainsString('txid123', $html);
     }
 

--- a/tests/php/GatewayFlowTest.php
+++ b/tests/php/GatewayFlowTest.php
@@ -141,9 +141,7 @@ class GatewayFlowTest extends TestCase {
         ob_start();
         (new WEO_Order())->render_order_panel(1);
         $html = ob_get_clean();
-        $this->assertStringContainsString('PSBT kann jederzeit im Dokan-Dashboard', $html);
-        $this->assertStringContainsString('Zum Treuhand-Dashboard', $html);
-        $this->assertStringContainsString('/weo-treuhand-orders', $html);
+        $this->assertStringContainsString('PSBT kann jederzeit über die Treuhand-Seite', $html);
         $this->assertStringContainsString('txid123', $html);
     }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -71,7 +71,7 @@ function check_admin_referer($a=-1,$q='_wpnonce'){return true;}
 function current_time($t){return time();}
 function wp_next_scheduled($h,$a=[]){return false;}
 function wp_schedule_single_event($ts,$h,$a=[]){ global $scheduled; $scheduled[]=['ts'=>$ts,'hook'=>$h,'args'=>$a]; }
-function dokan_get_navigation_url($p){ return '/'.$p; }
+function dokan_get_navigation_url($p){ return '/dashboard/'.$p; }
 function wc_mail($to,$subject,$message){ global $mails; $mails[]=['to'=>$to,'subject'=>$subject,'message'=>$message]; }
 function get_userdata($id){ return (object)['user_email'=>'vendor'.$id.'@example.com']; }
 function get_user_meta($id,$key,$single=true){ return ''; }

--- a/woo-escrow-onchain.php
+++ b/woo-escrow-onchain.php
@@ -18,14 +18,23 @@ require_once WEO_DIR.'includes/class-psbt.php';
 require_once WEO_DIR.'includes/class-escrow-settings.php';
 require_once WEO_DIR.'includes/class-escrow-vendor.php';
 require_once WEO_DIR.'includes/class-escrow-dokan.php';
-require_once WEO_DIR.'includes/class-escrow-gateway.php';
 require_once WEO_DIR.'includes/class-escrow-order.php';
 require_once WEO_DIR.'includes/class-escrow-rest.php';
 require_once WEO_DIR.'includes/class-escrow-admin.php';
 require_once WEO_DIR.'includes/class-escrow-notifications.php';
 
 add_action('plugins_loaded', function() {
-  if (!class_exists('WooCommerce')) return;
+  if (!class_exists('WooCommerce')) {
+    return;
+  }
+
+  require_once WEO_DIR . 'includes/class-escrow-gateway.php';
+
+  add_filter('woocommerce_payment_gateways', function($methods) {
+    $methods[] = 'WEO_Gateway';
+    return $methods;
+  });
+
   new WEO_Settings();
   new WEO_Vendor();
   if (function_exists('dokan')) new WEO_Dokan();
@@ -33,9 +42,4 @@ add_action('plugins_loaded', function() {
   new WEO_REST();
   if (is_admin()) new WEO_Admin();
   WEO_Notifications::init();
-});
-
-add_filter('woocommerce_payment_gateways', function($methods) {
-  $methods[] = 'WEO_Gateway';
-  return $methods;
 });

--- a/woo-escrow-onchain.php
+++ b/woo-escrow-onchain.php
@@ -23,6 +23,10 @@ require_once WEO_DIR.'includes/class-escrow-rest.php';
 require_once WEO_DIR.'includes/class-escrow-admin.php';
 require_once WEO_DIR.'includes/class-escrow-notifications.php';
 
+register_activation_hook(WEO_PLUGIN_FILE, function() {
+  flush_rewrite_rules();
+});
+
 add_action('plugins_loaded', function() {
   if (!class_exists('WooCommerce')) {
     return;

--- a/woo-escrow-onchain.php
+++ b/woo-escrow-onchain.php
@@ -23,10 +23,6 @@ require_once WEO_DIR.'includes/class-escrow-rest.php';
 require_once WEO_DIR.'includes/class-escrow-admin.php';
 require_once WEO_DIR.'includes/class-escrow-notifications.php';
 
-register_activation_hook(WEO_PLUGIN_FILE, function() {
-  flush_rewrite_rules();
-});
-
 add_action('plugins_loaded', function() {
   if (!class_exists('WooCommerce')) {
     return;


### PR DESCRIPTION
## Summary
- require gateway class only after WooCommerce is available
- register payment gateway within plugins_loaded hook

## Testing
- `composer install`
- `./vendor/bin/phpunit --bootstrap tests/php/bootstrap.php tests/php`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba84ecc8832e90d2539a75d8718d